### PR TITLE
Refactor: Move Flask Dashboard credentials to config.yaml

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,11 +32,10 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from shared import (
     EXPIRE_WEEK, FLASK_DASHBOARD,
-    FLASK_DASHBOARD_USERNAME, FLASK_DASHBOARD_PASSWORD,
     limiter, ALL_URLS, get_lock, g_c, EXPIRE_YEARS,
     set_flask_restful_api, g_logger
 )
-from app_config import DEBUG, get_secret_key
+from app_config import DEBUG, get_secret_key, get_dashboard_credentials
 from models import User
 
 # Define the order of JavaScript modules for loading
@@ -206,9 +205,10 @@ def setup_monitoring_dashboard(app):
         from flask_monitoringdashboard.core.config import Config
         
         # Configure Flask-MonitoringDashboard
+        dashboard_credentials = get_dashboard_credentials()
         config = Config()
-        config.USERNAME = FLASK_DASHBOARD_USERNAME
-        config.PASSWORD = FLASK_DASHBOARD_PASSWORD
+        config.USERNAME = dashboard_credentials.get('username')
+        config.PASSWORD = dashboard_credentials.get('password')
         config.DATABASE = 'sqlite:///flask_monitoringdashboard.db'
         
         # Initialize with custom configuration

--- a/app_config.py
+++ b/app_config.py
@@ -262,6 +262,16 @@ def get_admin_password() -> Optional[str]:
     """
     return config_manager.get('admin.password')
 
+
+def get_dashboard_credentials() -> Dict[str, str]:
+    """
+    Get the dashboard credentials from configuration.
+
+    Returns:
+        Dict[str, str]: A dictionary with 'username' and 'password' keys.
+    """
+    return config_manager.get('admin.dashboard', {})
+
 def get_secret_key() -> Optional[str]:
     """
     Get the secret key from configuration.

--- a/config.yaml
+++ b/config.yaml
@@ -5,6 +5,9 @@
 admin:
   password: "LinuxReportAdmin2024"
   secret_key: "your-super-secret-key-change-this-in-production"
+  dashboard:
+    username: "admin"
+    password: "admin"
 
 # Storage settings
 storage:

--- a/shared.py
+++ b/shared.py
@@ -51,8 +51,6 @@ from request_utils import get_rate_limit_key, dynamic_rate_limit, get_ip_prefix,
 
 # Flask-MonitoringDashboard configuration
 FLASK_DASHBOARD = False
-FLASK_DASHBOARD_USERNAME = "admin"  # Change this to your preferred username
-FLASK_DASHBOARD_PASSWORD = "admin"  # Change this to your preferred password
 
 # =============================================================================
 # CONFIGURATION LOADING AND SETTINGS


### PR DESCRIPTION
Moved the hardcoded `FLASK_DASHBOARD_USERNAME` and `FLASK_DASHBOARD_PASSWORD` from `shared.py` to `config.yaml` under the `admin.dashboard` section.

Created a new helper function `get_dashboard_credentials` in `app_config.py` to load these values.

Updated `app.py` to use the new helper function, removing the dependency on the hardcoded values in `shared.py`.

This change improves configuration management and security by centralizing credentials in the configuration file, consistent with the existing application architecture.